### PR TITLE
Loggers - https://github.com/passmarked/ssl/issues/9

### DIFF
--- a/lib/models/runner.js
+++ b/lib/models/runner.js
@@ -183,6 +183,15 @@ module.exports = exports = function() {
         checks        = buildCheckList(vals.slice(1, vals.length));
         boostraps     = buildBootstrapList(vals.slice(1, vals.length));
 
+        // check if the option was defined ... ?
+        if(options.bootstrap && 
+            typeof options.bootstrap == 'function') {
+
+          // add the bootstrapped function
+          boostraps.push(options.bootstrap)
+
+        }
+
       } else {
 
         // build the list of checks

--- a/test/runner.js
+++ b/test/runner.js
@@ -14,6 +14,185 @@ describe('passmarked', function() {
 
     describe('#createRunner', function() {
 
+      it('Should execute the bootstrap command when simply passed as option with custom logger', function(done) {
+
+        var counter = 0;
+        var booted = false;
+        var logs = 0;
+
+        var runner = passmarked.createRunner({
+
+          logger:     {
+
+            info: function() { logs++; },
+            debug: function() { logs++; },
+            error: function() { logs++; },
+            warning: function() { logs++; }
+
+          },
+          bootstrap: function(logger, cb) {
+
+            // log something
+            logger.info('test!')
+
+            // set to true
+            booted = true;
+
+            // done
+            cb(null);
+
+          }
+
+        }, [
+
+          function(payload, cb) {
+
+            // should not be null/undefined object
+            if(payload === null)
+              assert.fail('Payload should not be null');
+            if(payload === undefined)
+              assert.fail('Payload should not be null');
+
+            // count up one
+            counter++;
+
+            cb();
+
+          }
+
+        ]);
+        runner.run({
+
+          url: 'http://example.com'
+
+        }, function(err, rules) {
+
+          // should not have a error
+          if(err) assert.fail('Was not expecting a error');
+          if(logs <= 0) assert.fail('Custom logger did not work');
+          if(booted == false) assert.fail('The bootstrap command has to be called')
+          if(!rules) assert.fail('Returned rules must not be blank');
+          if(counter != 1) assert.fail('Code was not execute for the module');
+
+          // done
+          done();
+
+        });
+
+      });
+
+      it('Should execute the bootstrap command when simply passed as option', function(done) {
+
+        var counter = 0;
+        var booted = false;
+
+        var runner = passmarked.createRunner({
+
+          bootstrap: function(logger, cb) {
+
+            // set to true
+            booted = true;
+
+            // done
+            cb(null);
+
+          }
+
+        }, [
+
+          function(payload, cb) {
+
+            // should not be null/undefined object
+            if(payload === null)
+              assert.fail('Payload should not be null');
+            if(payload === undefined)
+              assert.fail('Payload should not be null');
+
+            // count up one
+            counter++;
+
+            cb();
+
+          }
+
+        ]);
+        runner.run({
+
+          url: 'http://example.com'
+
+        }, function(err, rules) {
+
+          // should not have a error
+          if(err) assert.fail('Was not expecting a error');
+          if(booted == false) assert.fail('The bootstrap command has to be called')
+          if(!rules) assert.fail('Returned rules must not be blank');
+          if(counter != 1) assert.fail('Code was not execute for the module');
+
+          // done
+          done();
+
+        });
+
+      });
+
+      it('Should execute the bootstrap command when created as object', function(done) {
+
+        var counter = 0;
+        var booted = false;
+
+        var testParams = passmarked.createTest({
+
+          rules:  [
+
+            function(payload, cb) {
+
+              // should not be null/undefined object
+              if(payload === null)
+                assert.fail('Payload should not be null');
+              if(payload === undefined)
+                assert.fail('Payload should not be null');
+
+              // count up one
+              counter++;
+
+              cb();
+
+            }
+
+          ]
+
+        });
+
+        testParams.bootstrap = function(logger, cb) {
+
+          // set to true
+          booted = true;
+
+          // done
+          cb(null);
+
+        };
+
+        var runner = passmarked.createRunner(testParams);
+        runner.run({
+
+          url: 'http://example.com'
+
+        }, function(err, rules) {
+
+          // should not have a error
+          if(err) assert.fail('Was not expecting a error');
+          if(booted == false) assert.fail('The bootstrap command has to be called')
+          if(!rules) assert.fail('Returned rules must not be blank');
+          if(counter != 1) assert.fail('Code was not execute for the module');
+
+          // done
+          done();
+
+        });
+
+      });
+
       it('Should run one function and return as a callback', function(done) {
 
         var counter = 0;


### PR DESCRIPTION
Issue was reported over at https://github.com/passmarked/ssl/issues/9 that the following errors was happening:

```
TypeError: logger.info is not a function
at Test.bootstrap (/project/node_modules/@passmarked/ssl/index.js:30:10)
at async.each.loaded (/project/node_modules/passmarked/lib/models/runner.js:224:7)
at /project/node_modules/passmarked/node_modules/async/dist/async.js:3025:16
at eachOfArrayLike (/project/node_modules/passmarked/node_modules/async/dist/async.js:941:9)
at eachOf (/project/node_modules/passmarked/node_modules/async/dist/async.js:991:5)
at Object.eachLimit (/project/node_modules/passmarked/node_modules/async/dist/async.js:3089:3)
at Object.Runner.bootstrap (/project/node_modules/passmarked/lib/models/runner.js:221:11)
at /project/node_modules/passmarked/lib/models/runner.js:306:18
```

when the following code was run:

```
let passmarked = require('passmarked'),
    ssl = require('@passmarked/ssl');

passmarked.createRunner(ssl).run({url: 'testagent.cgos.info'})
    .then(info => console.log(info))
    .catch(err => console.log(err.stack));
```

Updated so a bootstrap function can be passed and added a bit of test coverage to stop issues like this in the future. The logger was never passed to the bootstrap, giving us this issue