### PR TITLE
Release v0.5.9

### DIFF
--- a/lib/models/payload.js
+++ b/lib/models/payload.js
@@ -395,12 +395,13 @@ module.exports = exports = function(params, har, content) {
   /**
   * Handles debugging messages
   **/
-  Payload.debug = function(message) {
+  Payload.debug = function(tag, message) {
 
     // add to the logs
     logs.push({
 
       type:       'debug',
+      tag:        tag,
       message:    message,
       timestamp:  new Date().getTime()
 
@@ -411,12 +412,13 @@ module.exports = exports = function(params, har, content) {
   /**
   * Handles information messages
   **/
-  Payload.info = function(message) {
+  Payload.info = function(tag, message) {
 
     // add to the logs
     logs.push({
 
       type:       'info',
+      tag:        tag,
       message:    message,
       timestamp:  new Date().getTime()
 
@@ -518,12 +520,13 @@ module.exports = exports = function(params, har, content) {
   /**
   * Handles and warnings that might be present
   **/
-  Payload.warning = function(message) {
+  Payload.warning = function(tag, message) {
 
     // add to the logs
     logs.push({
 
       type:       'warning',
+      tag:        tag,
       message:    message,
       timestamp:  new Date().getTime()
 
@@ -534,12 +537,13 @@ module.exports = exports = function(params, har, content) {
   /**
   * Handles logging error outputs
   **/
-  Payload.error = function(message, err) {
+  Payload.error = function(tag, message, err) {
 
     // add to the logs
     logs.push({
 
       type:       'error',
+      tag:        tag,
       message:    message,
       error:      err,
       timestamp:  new Date().getTime()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passmarked",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "A CLI for the passmarked.com service",
   "homepage": "http://passmarked.com",
   "preferGlobal": true,


### PR DESCRIPTION
Small maintenance release to fix issues we have been having with scaling now that the system is up and checking sites daily.

* Updates the open source logging infrastructure to more closely match our server side logging running on production in our cluster.
* Added the idea of **mentions** that allows "**site-wide**" issues, where the specific subject is only checked once and can be skipped if encountered again