### PR TITLE
Updated the feel when no token is present

### DIFF
--- a/lib/commands/submit.js
+++ b/lib/commands/submit.js
@@ -417,6 +417,9 @@ module.exports = exports = function(payload, fn) {
 
               }
 
+              // add a new line
+              textOutput.push('');
+
               // add our JSON
               jsonOutput.push(result.toJSON());
 

--- a/lib/commands/submit.js
+++ b/lib/commands/submit.js
@@ -3,6 +3,7 @@ const config        = require('../config');
 const _             = require('lodash');
 const API           = require('../api');
 const url           = require('url');
+const S             = require('string');
 const Channel       = require('../utils/channel');
 const async         = require('async');
 const passmarked    = require('../index');
@@ -29,7 +30,7 @@ module.exports = exports = function(payload, fn) {
   config.build(function(){
 
     // check if the user is logged and can submit these requests
-    if(config.getToken() === null) {
+    if(S(config.getToken()).isEmpty() === true) {
 
       // set the status code
       payload.setExecCode(1);

--- a/lib/commands/submit.js
+++ b/lib/commands/submit.js
@@ -28,6 +28,34 @@ module.exports = exports = function(payload, fn) {
   // build local config to use
   config.build(function(){
 
+    // check if the user is logged and can submit these requests
+    if(config.getToken() === null) {
+
+      // set the status code
+      payload.setExecCode(1);
+
+      // no token is present ...
+      payload.setText([
+
+        '',
+        'To run tests from the terminal client, a valid authenticated',
+        'user is required. To authenticate the terminal client run:',
+        '',
+        '\tpassmarked connect',
+        ''
+
+      ].join('\n'));
+      payload.setJSON({
+
+        message: 'To run tests first authenticate your terminal client to a user on the system. Run "passmarked connect" to get started.'
+
+      });
+
+      // stop exec
+      return fn(null);
+
+    }
+
     // run the track
     api.track({
 


### PR DESCRIPTION
Small update that updates the versions of all the dependencies along with the text before a user is authenticated:

```
To run tests from the terminal client, a valid authenticated
user is required. To authenticate the terminal client run:

	passmarked connect

```