### PR TITLE
Fix CL breaking typo in config.js

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -159,7 +159,7 @@ Config.init = function(fn) {
 
       Config.getFile(),
       JSON.stringify(Constants.BASIC_CONFIG),
-      function(errr) {
+      function(err) {
 
         // indicate that this is a new run
         fn(err, true);


### PR DESCRIPTION
line 162: errr to err

Error on first command after npm install:
        fn(err, true);
           ^

ReferenceError: err is not defined
    at /Users/dancyfits/.config/yarn/global/node_modules/passmarked/lib/config.js:165:12

Sorry that I haven't included a test.  I didn't see any tests setup for config.js, haven't looked through the code enough to know how it all works yet, and I'm not confident in my ability to write tests just yet (coincidentally, that's my main learning focus for the next few days, so hopefully that'll change).

Since it's such a small change I thought I'd make a pull request anyway.  Now go back to PH and market this!